### PR TITLE
Improvement/correct spelling of dootstraper

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["Doostrapper", "boostrapper"]
+  "cSpell.words": ["Dootstrapper", "bootstrapper"]
 }

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 
-# CDK Deployment Boostrapper project
+# CDK Deployment Bootstrapper project
 
-![Build Status](https://github.com/nextfaze/doostrapper/workflows/ci/badge.svg)
+![Build Status](https://github.com/nextfaze/dootstrapper/workflows/ci/badge.svg)
 
 Creates a CD (Continuous delivery/deployment) pipeline to declaratively deploy to multiple environments.
 
 ## Getting Started [Internal Use Only]
 
-This getting started section contains information on how to get started for developing doostrapper
+This getting started section contains information on how to get started for developing dootstrapper
 
 ### Prerequisites
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,7 +4,7 @@
 # See https://docs.bazel.build/versions/master/build-ref.html#workspace
 workspace(
     # How this workspace would be referenced with absolute labels from another workspace
-    name = "doostrapper",
+    name = "dootstrapper",
     # Map the @npm bazel workspace to the node_modules directory.
     # This lets Bazel use the same node_modules as other local tooling.
     managed_directories = {

--- a/example/package.json
+++ b/example/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "doostrapper-example",
+  "name": "dootstrapper-example",
   "version": "1.0.0",
-  "description": "Example app to demonstrate simple usage of doostrapper package",
+  "description": "Example app to demonstrate simple usage of dootstrapper package",
   "main": "index.js",
   "scripts": {
     "test": "bazel test //..."
   },
   "keywords": [
     "aws-cdk",
-    "doostrapper"
+    "dootstrapper"
   ],
   "author": "Rushi Patel <rpatel@nextfaze.com>",
   "license": "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "doostrapper",
+  "name": "dootstrapper",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "doostrapper",
+  "name": "dootstrapper",
   "description": "Multi environment deployment Constructs App",
   "main": "index.js",
   "private": true,
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/whimzyLive/doostrapper"
+    "url": "https://github.com/whimzyLive/dootstrapper"
   },
-  "homepage": "https://github.com/whimzyLive/doostrapper/blob/master/README.md",
+  "homepage": "https://github.com/whimzyLive/dootstrapper/blob/master/README.md",
   "keywords": [
     "aws-cdk",
     "aws-cdk-deployment",
-    "aws-cdk-boostrapper"
+    "aws-cdk-bootstrapper"
   ],
   "devDependencies": {
     "@aws-cdk/assert": "^1.23.0",
@@ -41,13 +41,13 @@
     "typescript": "~3.7.5"
   },
   "scripts": {
-    "build": "bazel build //...",
+    "build": "bazel build ${TARGET:-//...}",
     "check": "bazel version",
     "test": "bazel test //...",
     "install:all": "bazel run @nodejs//:npm_node_repositories install",
     "add-dep": "bazel run @nodejs//:npm_node_repositories install",
-    "pack": "bazel run //package:doostrapper.pack",
-    "publish": "bazel run //package:doostrapper.publish",
+    "pack": "bazel run //package:dootstrapper.pack",
+    "publish": "bazel run //package:dootstrapper.publish",
     "build:watch": "ibazel build //...",
     "test:watch": "ibazel test //...",
     "bazel:format": "find . -type f \\( -name \"*.bzl\" -or -name WORKSPACE -or -name BUILD -or -name BUILD.bazel \\) ! -path \"*/node_modules/*\" | xargs buildifier -v --warnings=attr-cfg,attr-license,attr-non-empty,attr-output-default,attr-single-file,constant-glob,ctx-actions,ctx-args,depset-iteration,depset-union,dict-concatenation,duplicated-name,filetype,git-repository,http-archive,integer-division,load,load-on-top,native-build,native-package,out-of-order-load,output-group,package-name,package-on-top,positional-args,redefined-variable,repository-name,same-origin-load,string-iteration,unsorted-dict-items,unused-variable",

--- a/package/README.md
+++ b/package/README.md
@@ -1,4 +1,4 @@
-# CDK Deployment Boostrapper project
+# CDK Deployment Bootstrapper project
 
 Creates a CD pipeline to declaratively deploy to multiple environments
 Generates following resources:

--- a/package/index.ts
+++ b/package/index.ts
@@ -1,6 +1,6 @@
 export * from './resources/doostrapper-delivery';
 export { NOTIFICATIONS_TARGET, NOTIFICATIONS_TYPE } from './resources/enums';
 export {
-  IDoostrapperDelivery,
-  IDoostrapperDeliveryProps,
+  IDootstrapperDelivery,
+  IDootstrapperDeliveryProps,
 } from './resources/interfaces';

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "doostrapper",
+  "name": "dootstrapper",
   "version": "0.1.8-alpha.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package/package.json
+++ b/package/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "doostrapper",
+  "name": "dootstrapper",
   "version": "0.1.8-alpha.0",
-  "description": "Multi environment deployment boostrapper",
+  "description": "Multi environment deployment bootstrapper",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/whimzyLive/doostrapper"
+    "url": "https://github.com/whimzyLive/dootstrapper"
   },
-  "homepage": "https://github.com/whimzyLive/doostrapper/blob/master/package/README.md",
+  "homepage": "https://github.com/whimzyLive/dootstrapper/blob/master/package/README.md",
   "keywords": [
     "aws-cdk",
     "continuous delivery",
     "continuous deployment",
-    "boostrapper"
+    "bootstrapper"
   ],
   "module": "ES6",
   "license": "MIT",

--- a/package/resources/constructs/core.spec.ts
+++ b/package/resources/constructs/core.spec.ts
@@ -54,7 +54,7 @@ describe('Core construct ', () => {
       expectCDK(stack).to(
         haveResource('AWS::SSM::Parameter', {
           Type: 'String',
-          Name: '/doostrapper/test/access_key_id',
+          Name: '/dootstrapper/test/access_key_id',
           Value: {
             Ref: 'CoreDeployCredentials7007E7FA',
           },
@@ -63,7 +63,7 @@ describe('Core construct ', () => {
       expectCDK(stack).to(
         haveResource('AWS::SSM::Parameter', {
           Type: 'String',
-          Name: '/doostrapper/test/secret_access_key',
+          Name: '/dootstrapper/test/secret_access_key',
           Value: {
             'Fn::GetAtt': ['CoreDeployCredentials7007E7FA', 'SecretAccessKey'],
           },
@@ -91,14 +91,14 @@ describe('Core construct ', () => {
       expectCDK(stack).to(
         haveResource('AWS::SSM::Parameter', {
           Type: 'String',
-          Name: '/doostrapper/test/access_key_id',
+          Name: '/dootstrapper/test/access_key_id',
           Value: 'ACCESS_KEY_ID',
         })
       );
       expectCDK(stack).to(
         haveResource('AWS::SSM::Parameter', {
           Type: 'String',
-          Name: '/doostrapper/test/secret_access_key',
+          Name: '/dootstrapper/test/secret_access_key',
           Value: 'SECRET_ACCESS_KEY',
         })
       );

--- a/package/resources/constructs/core.ts
+++ b/package/resources/constructs/core.ts
@@ -33,11 +33,11 @@ export class Core extends Construct {
     // create string parameter even if admin Permissions in not allowed
     // developer will be responsible for adding values to this param
     this.accessKeyId = new StringParameter(this, 'DeployAccessKeyId', {
-      parameterName: `/doostrapper/${environmentName}/access_key_id`,
+      parameterName: `/dootstrapper/${environmentName}/access_key_id`,
       stringValue: this.credentials?.ref || 'ACCESS_KEY_ID',
     });
     this.secretAccessKey = new StringParameter(this, 'DeploySecretAccessKey', {
-      parameterName: `/doostrapper/${environmentName}/secret_access_key`,
+      parameterName: `/dootstrapper/${environmentName}/secret_access_key`,
       stringValue: this.credentials?.attrSecretAccessKey || 'SECRET_ACCESS_KEY',
     });
   }

--- a/package/resources/constructs/multi-env-pipeline.spec.ts
+++ b/package/resources/constructs/multi-env-pipeline.spec.ts
@@ -151,7 +151,7 @@ describe('MultiEnvPipeline', () => {
                       ':parameter',
                       {
                         Ref:
-                          'MultiEnvPipelinetestDoostrapperCoreDeployAccessKeyId6E97CF1F',
+                          'MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F',
                       },
                     ],
                   ],
@@ -184,7 +184,7 @@ describe('MultiEnvPipeline', () => {
                       ':parameter',
                       {
                         Ref:
-                          'MultiEnvPipelinetestDoostrapperCoreDeploySecretAccessKey89E012B2',
+                          'MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2',
                       },
                     ],
                   ],

--- a/package/resources/constructs/multi-env-pipeline.spec.ts
+++ b/package/resources/constructs/multi-env-pipeline.spec.ts
@@ -151,7 +151,7 @@ describe('MultiEnvPipeline', () => {
                       ':parameter',
                       {
                         Ref:
-                          'MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F',
+                          'MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId1ABD3E78',
                       },
                     ],
                   ],
@@ -184,7 +184,7 @@ describe('MultiEnvPipeline', () => {
                       ':parameter',
                       {
                         Ref:
-                          'MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2',
+                          'MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey90E4971B',
                       },
                     ],
                   ],

--- a/package/resources/constructs/multi-env-pipeline.ts
+++ b/package/resources/constructs/multi-env-pipeline.ts
@@ -60,7 +60,7 @@ export class MultiEnvPipeline extends Construct {
       const { adminPermissions = false } = environment;
       const { accessKeyId, secretAccessKey } = new Core(
         this,
-        `${environment.name}DoostrapperCore`,
+        `${environment.name}DootstrapperCore`,
         {
           adminPermissions,
           environmentName: environment.name,
@@ -150,7 +150,7 @@ export class MultiEnvPipeline extends Construct {
         environmentVariables: runtimeVariables,
         computeType: ComputeType.SMALL,
       },
-      description: `Doostrapper Codepipeline Deploy Project for stage ${stage}`,
+      description: `Dootstrapper Codepipeline Deploy Project for stage ${stage}`,
     });
     accessKeyId.grantRead(deployProject);
     secretAccessKey.grantRead(deployProject);

--- a/package/resources/doostrapper-delivery.ts
+++ b/package/resources/doostrapper-delivery.ts
@@ -9,8 +9,12 @@ import { App, Stack } from '@aws-cdk/core';
 import { EMAIL_VALIDATOR } from './constants';
 import { MultiEnvPipeline } from './constructs/multi-env-pipeline';
 import { NOTIFICATIONS_DETAILS_TYPE, NOTIFICATIONS_TYPE } from './enums';
-import { IDootstrapperDelivery, IDootstrapperDeliveryProps } from './interfaces';
-export class DootstrapperDelivery extends Stack implements IDootstrapperDelivery {
+import {
+  IDootstrapperDelivery,
+  IDootstrapperDeliveryProps,
+} from './interfaces';
+export class DootstrapperDelivery extends Stack
+  implements IDootstrapperDelivery {
   public readonly artifactsBucket: Bucket;
   public readonly deployPipeline: Pipeline;
   public readonly notificationsTopic: Topic;

--- a/package/resources/doostrapper-delivery.ts
+++ b/package/resources/doostrapper-delivery.ts
@@ -9,8 +9,8 @@ import { App, Stack } from '@aws-cdk/core';
 import { EMAIL_VALIDATOR } from './constants';
 import { MultiEnvPipeline } from './constructs/multi-env-pipeline';
 import { NOTIFICATIONS_DETAILS_TYPE, NOTIFICATIONS_TYPE } from './enums';
-import { IDoostrapperDelivery, IDoostrapperDeliveryProps } from './interfaces';
-export class DoostrapperDelivery extends Stack implements IDoostrapperDelivery {
+import { IDootstrapperDelivery, IDootstrapperDeliveryProps } from './interfaces';
+export class DootstrapperDelivery extends Stack implements IDootstrapperDelivery {
   public readonly artifactsBucket: Bucket;
   public readonly deployPipeline: Pipeline;
   public readonly notificationsTopic: Topic;
@@ -18,7 +18,7 @@ export class DoostrapperDelivery extends Stack implements IDoostrapperDelivery {
   constructor(
     scope: App,
     id: string,
-    private props: IDoostrapperDeliveryProps
+    private props: IDootstrapperDeliveryProps
   ) {
     super(scope, id, props);
 
@@ -100,7 +100,7 @@ export class DoostrapperDelivery extends Stack implements IDoostrapperDelivery {
     return new Rule(this, 'PipelineNotificationsRule', {
       targets: [snsTopic],
       enabled: true,
-      description: 'Doostrapper Pipeline notifications Cloudwatch Rule',
+      description: 'Dootstrapper Pipeline notifications Cloudwatch Rule',
       ruleName: cloudwatchRuleName,
       eventPattern: {
         source: ['aws.codepipeline'],

--- a/package/resources/dootstrapper-delivery.spec.ts
+++ b/package/resources/dootstrapper-delivery.spec.ts
@@ -5,18 +5,18 @@ import {
   matchTemplate,
 } from '@aws-cdk/assert';
 import { App, Stack } from '@aws-cdk/core';
-import { DoostrapperDelivery } from './doostrapper-delivery';
+import { DootstrapperDelivery } from './doostrapper-delivery';
 import { NOTIFICATIONS_TARGET, NOTIFICATIONS_TYPE } from './enums';
 const stackWithMinConfig = require('./test/stack-with-min-config.spec.json');
 const stackWithCustomConfig = require('./test/stack-with-custom-config.spec.json');
 
-describe('Doostrapper', () => {
+describe('Dootstrapper', () => {
   let stack: Stack;
 
   describe('Stack with minimum config', () => {
     beforeAll(() => {
       const app = new App();
-      stack = new DoostrapperDelivery(app, 'TestStack', {
+      stack = new DootstrapperDelivery(app, 'TestStack', {
         stackName: 'test-stack',
         pipelineConfig: {
           artifactsSourceKey: 'path/to/resource.zip',
@@ -115,7 +115,7 @@ describe('Doostrapper', () => {
     it('should create cloudwatch event rule to listen to pipeline execution status change', () => {
       expectCDK(stack).to(
         haveResource('AWS::Events::Rule', {
-          Description: 'Doostrapper Pipeline notifications Cloudwatch Rule',
+          Description: 'Dootstrapper Pipeline notifications Cloudwatch Rule',
           EventPattern: {
             source: ['aws.codepipeline'],
             'detail-type': ['CodePipeline Pipeline Execution State Change'],
@@ -162,7 +162,7 @@ describe('Doostrapper', () => {
   describe('stack with stage execution status config', () => {
     beforeAll(() => {
       const app = new App();
-      stack = new DoostrapperDelivery(app, 'TestStack', {
+      stack = new DootstrapperDelivery(app, 'TestStack', {
         stackName: 'test-stack',
         pipelineConfig: {
           artifactsSourceKey: 'path/to/resource.zip',
@@ -187,7 +187,7 @@ describe('Doostrapper', () => {
     it('should create event rule to listen to pipeline stage execution config', () => {
       expectCDK(stack).to(
         haveResource('AWS::Events::Rule', {
-          Description: 'Doostrapper Pipeline notifications Cloudwatch Rule',
+          Description: 'Dootstrapper Pipeline notifications Cloudwatch Rule',
           EventPattern: {
             source: ['aws.codepipeline'],
             'detail-type': ['CodePipeline Stage Execution State Change'],
@@ -234,7 +234,7 @@ describe('Doostrapper', () => {
   describe('stack with actions execution status config', () => {
     beforeAll(() => {
       const app = new App();
-      stack = new DoostrapperDelivery(app, 'TestStack', {
+      stack = new DootstrapperDelivery(app, 'TestStack', {
         stackName: 'test-stack',
         pipelineConfig: {
           artifactsSourceKey: 'path/to/resource.zip',
@@ -259,7 +259,7 @@ describe('Doostrapper', () => {
     it('should create event rule to listen to pipeline stage execution config', () => {
       expectCDK(stack).to(
         haveResource('AWS::Events::Rule', {
-          Description: 'Doostrapper Pipeline notifications Cloudwatch Rule',
+          Description: 'Dootstrapper Pipeline notifications Cloudwatch Rule',
           EventPattern: {
             source: ['aws.codepipeline'],
             'detail-type': ['CodePipeline Action Execution State Change'],
@@ -306,7 +306,7 @@ describe('Doostrapper', () => {
   describe('stack with all custom config', () => {
     beforeAll(() => {
       const app = new App();
-      stack = new DoostrapperDelivery(app, 'TestStack', {
+      stack = new DootstrapperDelivery(app, 'TestStack', {
         stackName: 'test-stack',
         artifactsBucketConfig: {
           bucketName: 'unique-artifacts-bucket-name',

--- a/package/resources/interfaces.ts
+++ b/package/resources/interfaces.ts
@@ -5,7 +5,7 @@ import { Topic } from '@aws-cdk/aws-sns';
 import { StackProps } from '@aws-cdk/core';
 import { NOTIFICATIONS_TARGET, NOTIFICATIONS_TYPE } from './enums';
 
-export interface IDoostrapperDelivery {
+export interface IDootstrapperDelivery {
   readonly artifactsBucket: Bucket;
   readonly deployPipeline: Pipeline;
   readonly notificationsTopic: Topic;
@@ -17,9 +17,9 @@ export interface IDoostrapperDelivery {
  * @param pipelineConfig Deploy pipeline related config
  * @param notificationsConfig Deployment notifications related config
  */
-export interface IDoostrapperDeliveryProps extends StackProps {
+export interface IDootstrapperDeliveryProps extends StackProps {
   /**
-   * @default - Doostrapper specific config is applied
+   * @default - Dootstrapper specific config is applied
    */
   artifactsBucketConfig?: IArtifactsBucketProps;
   pipelineConfig: IPipelineProps;

--- a/package/resources/test/stack-with-custom-config.spec.json
+++ b/package/resources/test/stack-with-custom-config.spec.json
@@ -499,7 +499,7 @@
         ]
       }
     },
-    "MultiEnvPipelinetestDoostrapperCoreDeployUser359F0069": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployUser359F0069": {
       "Type": "AWS::IAM::User",
       "Properties": {
         "ManagedPolicyArns": [
@@ -518,35 +518,35 @@
         ]
       }
     },
-    "MultiEnvPipelinetestDoostrapperCoreDeployCredentialsC6276BF7": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployCredentialsC6276BF7": {
       "Type": "AWS::IAM::AccessKey",
       "Properties": {
         "UserName": {
-          "Ref": "MultiEnvPipelinetestDoostrapperCoreDeployUser359F0069"
+          "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployUser359F0069"
         }
       }
     },
-    "MultiEnvPipelinetestDoostrapperCoreDeployAccessKeyId6E97CF1F": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
         "Value": {
-          "Ref": "MultiEnvPipelinetestDoostrapperCoreDeployCredentialsC6276BF7"
+          "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployCredentialsC6276BF7"
         },
-        "Name": "/doostrapper/test/access_key_id"
+        "Name": "/dootstrapper/test/access_key_id"
       }
     },
-    "MultiEnvPipelinetestDoostrapperCoreDeploySecretAccessKey89E012B2": {
+    "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
         "Value": {
           "Fn::GetAtt": [
-            "MultiEnvPipelinetestDoostrapperCoreDeployCredentialsC6276BF7",
+            "MultiEnvPipelinetestDootstrapperCoreDeployCredentialsC6276BF7",
             "SecretAccessKey"
           ]
         },
-        "Name": "/doostrapper/test/secret_access_key"
+        "Name": "/dootstrapper/test/secret_access_key"
       }
     },
     "MultiEnvPipelineTestPipelineProjectRoleCE42161B": {
@@ -654,7 +654,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDoostrapperCoreDeployAccessKeyId6E97CF1F"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
                     }
                   ]
                 ]
@@ -686,7 +686,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDoostrapperCoreDeploySecretAccessKey89E012B2"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
                     }
                   ]
                 ]
@@ -762,11 +762,11 @@
               [
                 "{\n  \"env\": {\n    \"variables\": {\n      \"AWS_DEFAULT_REGION\": \"ap-southeast-2\"\n    },\n    \"parameter-store\": {\n      \"AWS_ACCESS_KEY_ID\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDoostrapperCoreDeployAccessKeyId6E97CF1F"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
                 },
                 "\",\n      \"AWS_SECRET_ACCESS_KEY\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDoostrapperCoreDeploySecretAccessKey89E012B2"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
                 },
                 "\"\n    }\n  }\n}"
               ]
@@ -774,14 +774,14 @@
           },
           "Type": "CODEPIPELINE"
         },
-        "Description": "Doostrapper Codepipeline Deploy Project for stage TestDeploy",
+        "Description": "Dootstrapper Codepipeline Deploy Project for stage TestDeploy",
         "Name": "test-pipeline-project"
       }
     },
     "PipelineNotificationsRule108C77DD": {
       "Type": "AWS::Events::Rule",
       "Properties": {
-        "Description": "Doostrapper Pipeline notifications Cloudwatch Rule",
+        "Description": "Dootstrapper Pipeline notifications Cloudwatch Rule",
         "EventPattern": {
           "source": ["aws.codepipeline"],
           "detail-type": ["CodePipeline Pipeline Execution State Change"],

--- a/package/resources/test/stack-with-custom-config.spec.json
+++ b/package/resources/test/stack-with-custom-config.spec.json
@@ -15,8 +15,12 @@
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
-          "source": ["aws.s3"],
-          "detail-type": ["AWS API Call via CloudTrail"],
+          "source": [
+            "aws.s3"
+          ],
+          "detail-type": [
+            "AWS API Call via CloudTrail"
+          ],
           "detail": {
             "resources": {
               "ARN": [
@@ -25,7 +29,10 @@
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/path/to/resource.zip"
                     ]
@@ -33,14 +40,20 @@
                 }
               ]
             },
-            "eventName": ["CompleteMultipartUpload", "CopyObject", "PutObject"],
+            "eventName": [
+              "CompleteMultipartUpload",
+              "CopyObject",
+              "PutObject"
+            ],
             "requestParameters": {
               "bucketName": [
                 {
                   "Ref": "ArtifactsBucket2AAC5544"
                 }
               ],
-              "key": ["path/to/resource.zip"]
+              "key": [
+                "path/to/resource.zip"
+              ]
             }
           }
         },
@@ -72,7 +85,10 @@
             },
             "Id": "Target0",
             "RoleArn": {
-              "Fn::GetAtt": ["MultiEnvPipelineEventsRoleA222D099", "Arn"]
+              "Fn::GetAtt": [
+                "MultiEnvPipelineEventsRoleA222D099",
+                "Arn"
+              ]
             }
           }
         ]
@@ -154,14 +170,20 @@
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -204,7 +226,10 @@
       "Type": "AWS::CodePipeline::Pipeline",
       "Properties": {
         "RoleArn": {
-          "Fn::GetAtt": ["MultiEnvPipelineRole142940FD", "Arn"]
+          "Fn::GetAtt": [
+            "MultiEnvPipelineRole142940FD",
+            "Arn"
+          ]
         },
         "Stages": [
           {
@@ -327,18 +352,28 @@
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": ["s3:GetObject*", "s3:GetBucket*", "s3:List*"],
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*"
+              ],
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -347,18 +382,28 @@
               ]
             },
             {
-              "Action": ["s3:DeleteObject*", "s3:PutObject*", "s3:Abort*"],
+              "Action": [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*"
+              ],
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -499,7 +544,7 @@
         ]
       }
     },
-    "MultiEnvPipelinetestDootstrapperCoreDeployUser359F0069": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployUser641A1FC9": {
       "Type": "AWS::IAM::User",
       "Properties": {
         "ManagedPolicyArns": [
@@ -518,31 +563,31 @@
         ]
       }
     },
-    "MultiEnvPipelinetestDootstrapperCoreDeployCredentialsC6276BF7": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployCredentials1D4EBD99": {
       "Type": "AWS::IAM::AccessKey",
       "Properties": {
         "UserName": {
-          "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployUser359F0069"
+          "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployUser641A1FC9"
         }
       }
     },
-    "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId1ABD3E78": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
         "Value": {
-          "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployCredentialsC6276BF7"
+          "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployCredentials1D4EBD99"
         },
         "Name": "/dootstrapper/test/access_key_id"
       }
     },
-    "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2": {
+    "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey90E4971B": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
         "Value": {
           "Fn::GetAtt": [
-            "MultiEnvPipelinetestDootstrapperCoreDeployCredentialsC6276BF7",
+            "MultiEnvPipelinetestDootstrapperCoreDeployCredentials1D4EBD99",
             "SecretAccessKey"
           ]
         },
@@ -654,7 +699,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId1ABD3E78"
                     }
                   ]
                 ]
@@ -686,7 +731,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey90E4971B"
                     }
                   ]
                 ]
@@ -704,14 +749,20 @@
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -762,11 +813,11 @@
               [
                 "{\n  \"env\": {\n    \"variables\": {\n      \"AWS_DEFAULT_REGION\": \"ap-southeast-2\"\n    },\n    \"parameter-store\": {\n      \"AWS_ACCESS_KEY_ID\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId1ABD3E78"
                 },
                 "\",\n      \"AWS_SECRET_ACCESS_KEY\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey90E4971B"
                 },
                 "\"\n    }\n  }\n}"
               ]
@@ -783,8 +834,12 @@
       "Properties": {
         "Description": "Dootstrapper Pipeline notifications Cloudwatch Rule",
         "EventPattern": {
-          "source": ["aws.codepipeline"],
-          "detail-type": ["CodePipeline Pipeline Execution State Change"],
+          "source": [
+            "aws.codepipeline"
+          ],
+          "detail-type": [
+            "CodePipeline Pipeline Execution State Change"
+          ],
           "resources": [
             {
               "Fn::Join": [
@@ -843,7 +898,10 @@
                 "Service": "cloudtrail.amazonaws.com"
               },
               "Resource": {
-                "Fn::GetAtt": ["S3SourceTrailS37D21E604", "Arn"]
+                "Fn::GetAtt": [
+                  "S3SourceTrailS37D21E604",
+                  "Arn"
+                ]
               }
             },
             {
@@ -862,7 +920,10 @@
                   "",
                   [
                     {
-                      "Fn::GetAtt": ["S3SourceTrailS37D21E604", "Arn"]
+                      "Fn::GetAtt": [
+                        "S3SourceTrailS37D21E604",
+                        "Arn"
+                      ]
                     },
                     "/AWSLogs/",
                     {
@@ -907,10 +968,16 @@
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": ["logs:PutLogEvents", "logs:CreateLogStream"],
+              "Action": [
+                "logs:PutLogEvents",
+                "logs:CreateLogStream"
+              ],
               "Effect": "Allow",
               "Resource": {
-                "Fn::GetAtt": ["S3SourceTrailLogGroupB099508C", "Arn"]
+                "Fn::GetAtt": [
+                  "S3SourceTrailLogGroupB099508C",
+                  "Arn"
+                ]
               }
             }
           ],
@@ -932,10 +999,16 @@
           "Ref": "S3SourceTrailS37D21E604"
         },
         "CloudWatchLogsLogGroupArn": {
-          "Fn::GetAtt": ["S3SourceTrailLogGroupB099508C", "Arn"]
+          "Fn::GetAtt": [
+            "S3SourceTrailLogGroupB099508C",
+            "Arn"
+          ]
         },
         "CloudWatchLogsRoleArn": {
-          "Fn::GetAtt": ["S3SourceTrailLogsRoleDDC8A909", "Arn"]
+          "Fn::GetAtt": [
+            "S3SourceTrailLogsRoleDDC8A909",
+            "Arn"
+          ]
         },
         "EnableLogFileValidation": true,
         "EventSelectors": [
@@ -949,7 +1022,10 @@
                       "",
                       [
                         {
-                          "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                          "Fn::GetAtt": [
+                            "ArtifactsBucket2AAC5544",
+                            "Arn"
+                          ]
                         },
                         "/path/to/resource.zip"
                       ]

--- a/package/resources/test/stack-with-min-config.spec.json
+++ b/package/resources/test/stack-with-min-config.spec.json
@@ -14,8 +14,12 @@
       "Type": "AWS::Events::Rule",
       "Properties": {
         "EventPattern": {
-          "source": ["aws.s3"],
-          "detail-type": ["AWS API Call via CloudTrail"],
+          "source": [
+            "aws.s3"
+          ],
+          "detail-type": [
+            "AWS API Call via CloudTrail"
+          ],
           "detail": {
             "resources": {
               "ARN": [
@@ -24,7 +28,10 @@
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/path/to/resource.zip"
                     ]
@@ -32,14 +39,20 @@
                 }
               ]
             },
-            "eventName": ["CompleteMultipartUpload", "CopyObject", "PutObject"],
+            "eventName": [
+              "CompleteMultipartUpload",
+              "CopyObject",
+              "PutObject"
+            ],
             "requestParameters": {
               "bucketName": [
                 {
                   "Ref": "ArtifactsBucket2AAC5544"
                 }
               ],
-              "key": ["path/to/resource.zip"]
+              "key": [
+                "path/to/resource.zip"
+              ]
             }
           }
         },
@@ -71,7 +84,10 @@
             },
             "Id": "Target0",
             "RoleArn": {
-              "Fn::GetAtt": ["MultiEnvPipelineEventsRoleA222D099", "Arn"]
+              "Fn::GetAtt": [
+                "MultiEnvPipelineEventsRoleA222D099",
+                "Arn"
+              ]
             }
           }
         ]
@@ -150,14 +166,20 @@
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -200,7 +222,10 @@
       "Type": "AWS::CodePipeline::Pipeline",
       "Properties": {
         "RoleArn": {
-          "Fn::GetAtt": ["MultiEnvPipelineRole142940FD", "Arn"]
+          "Fn::GetAtt": [
+            "MultiEnvPipelineRole142940FD",
+            "Arn"
+          ]
         },
         "Stages": [
           {
@@ -323,18 +348,28 @@
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": ["s3:GetObject*", "s3:GetBucket*", "s3:List*"],
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*"
+              ],
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -343,18 +378,28 @@
               ]
             },
             {
-              "Action": ["s3:DeleteObject*", "s3:PutObject*", "s3:Abort*"],
+              "Action": [
+                "s3:DeleteObject*",
+                "s3:PutObject*",
+                "s3:Abort*"
+              ],
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -495,7 +540,7 @@
         ]
       }
     },
-    "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId1ABD3E78": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
@@ -503,7 +548,7 @@
         "Name": "/dootstrapper/test/access_key_id"
       }
     },
-    "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2": {
+    "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey90E4971B": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
@@ -616,7 +661,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId1ABD3E78"
                     }
                   ]
                 ]
@@ -648,7 +693,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey90E4971B"
                     }
                   ]
                 ]
@@ -666,14 +711,20 @@
               "Effect": "Allow",
               "Resource": [
                 {
-                  "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                  "Fn::GetAtt": [
+                    "ArtifactsBucket2AAC5544",
+                    "Arn"
+                  ]
                 },
                 {
                   "Fn::Join": [
                     "",
                     [
                       {
-                        "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                        "Fn::GetAtt": [
+                          "ArtifactsBucket2AAC5544",
+                          "Arn"
+                        ]
                       },
                       "/*"
                     ]
@@ -717,11 +768,11 @@
               [
                 "{\n  \"env\": {\n    \"parameter-store\": {\n      \"AWS_ACCESS_KEY_ID\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId1ABD3E78"
                 },
                 "\",\n      \"AWS_SECRET_ACCESS_KEY\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey90E4971B"
                 },
                 "\"\n    }\n  }\n}"
               ]
@@ -738,8 +789,12 @@
       "Properties": {
         "Description": "Dootstrapper Pipeline notifications Cloudwatch Rule",
         "EventPattern": {
-          "source": ["aws.codepipeline"],
-          "detail-type": ["CodePipeline Pipeline Execution State Change"],
+          "source": [
+            "aws.codepipeline"
+          ],
+          "detail-type": [
+            "CodePipeline Pipeline Execution State Change"
+          ],
           "resources": [
             {
               "Fn::Join": [
@@ -797,7 +852,10 @@
                 "Service": "cloudtrail.amazonaws.com"
               },
               "Resource": {
-                "Fn::GetAtt": ["S3SourceTrailS37D21E604", "Arn"]
+                "Fn::GetAtt": [
+                  "S3SourceTrailS37D21E604",
+                  "Arn"
+                ]
               }
             },
             {
@@ -816,7 +874,10 @@
                   "",
                   [
                     {
-                      "Fn::GetAtt": ["S3SourceTrailS37D21E604", "Arn"]
+                      "Fn::GetAtt": [
+                        "S3SourceTrailS37D21E604",
+                        "Arn"
+                      ]
                     },
                     "/AWSLogs/",
                     {
@@ -861,10 +922,16 @@
         "PolicyDocument": {
           "Statement": [
             {
-              "Action": ["logs:PutLogEvents", "logs:CreateLogStream"],
+              "Action": [
+                "logs:PutLogEvents",
+                "logs:CreateLogStream"
+              ],
               "Effect": "Allow",
               "Resource": {
-                "Fn::GetAtt": ["S3SourceTrailLogGroupB099508C", "Arn"]
+                "Fn::GetAtt": [
+                  "S3SourceTrailLogGroupB099508C",
+                  "Arn"
+                ]
               }
             }
           ],
@@ -886,10 +953,16 @@
           "Ref": "S3SourceTrailS37D21E604"
         },
         "CloudWatchLogsLogGroupArn": {
-          "Fn::GetAtt": ["S3SourceTrailLogGroupB099508C", "Arn"]
+          "Fn::GetAtt": [
+            "S3SourceTrailLogGroupB099508C",
+            "Arn"
+          ]
         },
         "CloudWatchLogsRoleArn": {
-          "Fn::GetAtt": ["S3SourceTrailLogsRoleDDC8A909", "Arn"]
+          "Fn::GetAtt": [
+            "S3SourceTrailLogsRoleDDC8A909",
+            "Arn"
+          ]
         },
         "EnableLogFileValidation": true,
         "EventSelectors": [
@@ -903,7 +976,10 @@
                       "",
                       [
                         {
-                          "Fn::GetAtt": ["ArtifactsBucket2AAC5544", "Arn"]
+                          "Fn::GetAtt": [
+                            "ArtifactsBucket2AAC5544",
+                            "Arn"
+                          ]
                         },
                         "/path/to/resource.zip"
                       ]

--- a/package/resources/test/stack-with-min-config.spec.json
+++ b/package/resources/test/stack-with-min-config.spec.json
@@ -495,20 +495,20 @@
         ]
       }
     },
-    "MultiEnvPipelinetestDoostrapperCoreDeployAccessKeyId6E97CF1F": {
+    "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
         "Value": "ACCESS_KEY_ID",
-        "Name": "/doostrapper/test/access_key_id"
+        "Name": "/dootstrapper/test/access_key_id"
       }
     },
-    "MultiEnvPipelinetestDoostrapperCoreDeploySecretAccessKey89E012B2": {
+    "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2": {
       "Type": "AWS::SSM::Parameter",
       "Properties": {
         "Type": "String",
         "Value": "SECRET_ACCESS_KEY",
-        "Name": "/doostrapper/test/secret_access_key"
+        "Name": "/dootstrapper/test/secret_access_key"
       }
     },
     "MultiEnvPipelineTestPipelineProjectRoleCE42161B": {
@@ -616,7 +616,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDoostrapperCoreDeployAccessKeyId6E97CF1F"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
                     }
                   ]
                 ]
@@ -648,7 +648,7 @@
                     },
                     ":parameter",
                     {
-                      "Ref": "MultiEnvPipelinetestDoostrapperCoreDeploySecretAccessKey89E012B2"
+                      "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
                     }
                   ]
                 ]
@@ -717,11 +717,11 @@
               [
                 "{\n  \"env\": {\n    \"parameter-store\": {\n      \"AWS_ACCESS_KEY_ID\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDoostrapperCoreDeployAccessKeyId6E97CF1F"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeployAccessKeyId6E97CF1F"
                 },
                 "\",\n      \"AWS_SECRET_ACCESS_KEY\": \"",
                 {
-                  "Ref": "MultiEnvPipelinetestDoostrapperCoreDeploySecretAccessKey89E012B2"
+                  "Ref": "MultiEnvPipelinetestDootstrapperCoreDeploySecretAccessKey89E012B2"
                 },
                 "\"\n    }\n  }\n}"
               ]
@@ -729,14 +729,14 @@
           },
           "Type": "CODEPIPELINE"
         },
-        "Description": "Doostrapper Codepipeline Deploy Project for stage TestDeploy",
+        "Description": "Dootstrapper Codepipeline Deploy Project for stage TestDeploy",
         "Name": "test-pipeline-project"
       }
     },
     "PipelineNotificationsRule108C77DD": {
       "Type": "AWS::Events::Rule",
       "Properties": {
-        "Description": "Doostrapper Pipeline notifications Cloudwatch Rule",
+        "Description": "Dootstrapper Pipeline notifications Cloudwatch Rule",
         "EventPattern": {
           "source": ["aws.codepipeline"],
           "detail-type": ["CodePipeline Pipeline Execution State Change"],


### PR DESCRIPTION
Corrects spelling of dootstrapper/bootstrapper in all docs and classnames. Some file names still say "doostrapper"